### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --passWithNoTests --ci
+        env:
+          STRIPE_SECRET_KEY: sk_test_placeholder
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_placeholder

--- a/__tests__/products.test.ts
+++ b/__tests__/products.test.ts
@@ -39,9 +39,8 @@ describe("products", () => {
     expect(priceToCents(0.99)).toBe(99)
   })
 
-  it("getImageUrl returns picsum URL", () => {
+  it("getImageUrl returns local image path", () => {
     const url = getImageUrl("camera")
-    expect(url).toContain("picsum.photos")
     expect(url).toContain("camera")
   })
 


### PR DESCRIPTION
Closes #5

Adds `.github/workflows/ci.yml` — runs `npm ci` + `npm test` on every push/PR to main.

Also fixes `getImageUrl` test assertion (was checking for picsum.photos URL; updated after Ren swapped to local static images).

**33 tests pass.**